### PR TITLE
Update PIL antialiasing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Reader can read metadata and extract frames (into either .cur or .ico as encoded
 Writer can create .ani from .cur, .ico, or other file types like .png as supported by Iconolatry. .cur files may be created as needed and will be stored in the same folder as the .ani file. 
 
 ## Starting point
-Clone this repo or download package from Pypi with `pip install ani-file`:
+Clone this repo or download package from Pypi with `pip install ani_file`:
 
 Open ANI file in similar manner to builtin.open():
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Reader can read metadata and extract frames (into either .cur or .ico as encoded
 Writer can create .ani from .cur, .ico, or other file types like .png as supported by Iconolatry. .cur files may be created as needed and will be stored in the same folder as the .ani file. 
 
 ## Starting point
-Clone this repo or download package from Pypi with `pip install ani_file`:
+Clone this repo or download package from Pypi with `pip install ani-file`:
 
 Open ANI file in similar manner to builtin.open():
 ```

--- a/src/ani_file/Iconolatry.py
+++ b/src/ani_file/Iconolatry.py
@@ -1023,7 +1023,7 @@ class Encode(object):
                 image = self.extract(path_image)
 
                 ## Manage resize.
-                image = self.ico_resize(image, how = self.type_resize, method = Image.ANTIALIAS)
+                image = self.ico_resize(image, how = self.type_resize, method = Image.LANCZOS)
 
                 ## Manage ICC profile.
                 if 'icc_profile' in image.info:
@@ -1221,7 +1221,7 @@ class Encode(object):
                                 temp.append(self.parameters['palette'][i : i + step][::-1] + b'\x00')
                         self.parameters['palette'] = b"".join(temp)
 
-        def ico_resize(self, image, how = 'up256_prop', method = Image.ANTIALIAS):
+        def ico_resize(self, image, how = 'up256_prop', method = Image.LANCZOS):
                 """ Resizes to `.ico` / `.cur` dimensions. """
                 old_w, old_h = image.size
                 sizes = [16, 24, 32, 48, 64, 128, 256]


### PR DESCRIPTION
As of PIL >= 10.0.0, Image.ANTIALIAS has been removed in favor of Image.LANCZOS (which is present in PIL >= 2.7.0); using PIL >= 10.0.0 causes an exception in iconolatry.py. 